### PR TITLE
docs: update laravel valet link in mac os installation

### DIFF
--- a/content/id/docs/installation/mac.md
+++ b/content/id/docs/installation/mac.md
@@ -14,10 +14,10 @@ toc: true
 ---
 
 {{< alert icon="👉" context="info" >}}
-Untuk menginstall Buku Masjid di Mac OS tanpa menggunakan [Laravel Valet](https://laravel.com/docs/10.x/valet), bisa mengikuti panduan berikut: [Cara Install → Ubuntu/Linux Mint]({{< relref "docs/installation/ubuntu-linux-mint" >}}).
+Untuk menginstall Buku Masjid di Mac OS tanpa menggunakan Laravel Valet, bisa mengikuti panduan berikut: [Cara Install → Ubuntu/Linux Mint]({{< relref "docs/installation/ubuntu-linux-mint" >}}).
 {{< /alert >}}
 
-Untuk menginstall Buku Masjid di Mac OS dengan menggunakan Laravel Valet, bisa mengikuti panduan dibawah ini:
+Untuk menginstall Buku Masjid di Mac OS dengan menggunakan [Laravel Valet](https://laravel.com/docs/10.x/valet), bisa mengikuti panduan dibawah ini:
 
 1. Clone the repo : `git clone https://github.com/buku-masjid/buku-masjid.git`
 1. Gunakan PHP versi 8.1 : `valet use php@8.1`


### PR DESCRIPTION
Halo Mas @nafiesl, terkait PR #25, setelah saya lihat-lihat lagi, ketika di dark mode, link `Laravel Valet` di dalam shortcode alert menurut saya tulisannya terlalu terang dan aga susah dibaca, takutnya ga ke notice sama visitor. Karena itu menurut saya sebaiknya link nya dihilangin saja, terus link nya sendiri saya pindahin/tambahin di paragraph selanjutnya yang ga di dalem shortcode alert.

Kalo menurut Mas suggestion ini ok, minta tolong PR ini di review atau di merge ya Mas. kalo menurut Mas PR ini engga perlu, PR ini boleh di close aja ya Mas. Terima kasih.

## Checklist

- [x] Remove laravel valet link from alert shortcode cause it's too bright in dark mode that may can cause visitor not notice it
- [x] Add the laravel valet link in the next paragraph instead

### Before
<img width="794" alt="Screen Shot 2023-09-24 at 15 28 48" src="https://github.com/buku-masjid/docs/assets/25413225/e4709bce-9e3a-4536-9959-a3d6dfe6a79e">

### After
<img width="776" alt="Screen Shot 2023-09-24 at 15 31 53" src="https://github.com/buku-masjid/docs/assets/25413225/277ad787-7d26-4ca1-87cb-fdf0d19de4eb">
