### PR TITLE
Menambah tombol Hubungi Kami dengan link Whatsapp

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,11 +8,10 @@
     </div>
     <div class="col-lg-9 col-xl-8 text-center">
       <p class="lead">{{ .Params.lead | safeHTML }}</p>
-      <a class="btn btn-primary btn-lg px-4 mb-2" href="/docs/{{ if .Site.Params.options.docsVersioning }}{{ .Site.Params.docsVersion }}/{{ end }}prologue/introduction/" role="button">{{ i18n "get-started" }}</a>
-      <a class="btn btn-info btn-lg px-4 mb-2" href="/tutorial/transaction/list/" role="button">{{ i18n "read-tutorial" }}</a>
-      <a class="btn btn-secondary btn-lg px-4 mb-2" href="{{ .Site.Params.schemaGitHub }}" role="button">GitHub</a>
+      <a class="btn btn-primary btn-lg px-4 mb-2" href="/tutorial/transaction/list/" role="button">{{ i18n "read-tutorial" }}</a>
       {{ $whatsappNumber := getenv "HUGO_PARAMS_WHATSAPP_NUMBER" | default "0000" }}
-      <a class="btn btn-secondary btn-lg px-4 mb-2" target="_blank" href="https://wa.me/{{ $whatsappNumber }}" role="button">Hubungi Kami</a>
+      <a class="btn btn-info btn-lg px-4 mb-2" target="_blank" href="https://wa.me/{{ $whatsappNumber }}" role="button">Hubungi Kami</a>
+      <a class="btn btn-secondary btn-lg px-4 mb-2" href="{{ .Site.Params.schemaGitHub }}" role="button">Source Code</a>
       <p class="meta">Open-source MIT Licensed.</p>
     </div>
   </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -11,6 +11,8 @@
       <a class="btn btn-primary btn-lg px-4 mb-2" href="/docs/{{ if .Site.Params.options.docsVersioning }}{{ .Site.Params.docsVersion }}/{{ end }}prologue/introduction/" role="button">{{ i18n "get-started" }}</a>
       <a class="btn btn-info btn-lg px-4 mb-2" href="/tutorial/transaction/list/" role="button">{{ i18n "read-tutorial" }}</a>
       <a class="btn btn-secondary btn-lg px-4 mb-2" href="{{ .Site.Params.schemaGitHub }}" role="button">GitHub</a>
+      {{ $whatsappNumber := getenv "HUGO_PARAMS_WHATSAPP_NUMBER" | default "0000" }}
+      <a class="btn btn-secondary btn-lg px-4 mb-2" target="_blank" href="https://wa.me/{{ $whatsappNumber }}" role="button">Hubungi Kami</a>
       <p class="meta">Open-source MIT Licensed.</p>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Pada PR ini kita menambahkan tombol "Hubungi Kami" dengan link whatsapp, jika ada pembaca yang membutuhkan bantuan tim Buku masjid.

Pada implementasinya kita menggunakan env variable untuk menyimpan nomor whatsapp, agar nomor whatsapp tersebut tidak perlu masuk git commit.

## Test di localhost

Untuk mengisi nomor whatsapp dengan env variable, kita tambahkan env saat start hugo server:
```
env HUGO_PARAMS_WHATSAPP_NUMBER="6281234567890" npm run start
```



## Checklist

- [x] Menambah tombol link whatsapp
- [x] Menggunakan env variabel untuk nomor whatsapp 
- [x] Menghapus link panduan
- [x] Mengganti label text tombol "Github" menjadi "Source Code"
